### PR TITLE
feat: search refactor

### DIFF
--- a/blog/blocks/app-cards/app-cards.js
+++ b/blog/blocks/app-cards/app-cards.js
@@ -1,17 +1,19 @@
 import { createOptimizedPicture, toClassName } from '../../scripts/scripts.js';
 import { filterResults } from '../listing/listing.js';
 
-function createAppCard(app, prefix) {
+export function createAppCard(app, prefix) {
   const card = document.createElement('li');
   card.className = `${prefix}-card`;
   const title = app.title.split(' - ')[0];
   const level = app.level ? `<img src="/blog/icons/${toClassName(app.level)}-badge.svg">` : '';
   const picture = createOptimizedPicture(app.image, title, false, [{ width: 750 }]).outerHTML;
+  const searchTags = app.searchTags ? `<div class="${prefix}-card-search-tags"><span>${app.searchTags.split(',').join('</span><span>')}</span></div>` : '';
   card.innerHTML = `<div class="${prefix}-card-image">${picture}</div>
   <div class="${prefix}-card-body">
   <div class="${prefix}-card-header"><h4>${title}</h4>${level}</div>
   <div class="${prefix}-card-detail"><p>${app.description}</p>
   <a href="${app.path}">Learn More</a></div>
+  ${searchTags}
   </div>`;
   return (card);
 }

--- a/blog/blocks/app-cards/app-cards.js
+++ b/blog/blocks/app-cards/app-cards.js
@@ -1,5 +1,10 @@
-import { createOptimizedPicture, toClassName } from '../../scripts/scripts.js';
-import { filterResults } from '../listing/listing.js';
+import {
+  createOptimizedPicture,
+  toClassName,
+  lookupPages,
+  readBlockConfig,
+  toCamelCase,
+} from '../../scripts/scripts.js';
 
 export function createAppCard(app, prefix) {
   const card = document.createElement('li');
@@ -18,13 +23,116 @@ export function createAppCard(app, prefix) {
   return (card);
 }
 
-export default async function decorate(block, blockName) {
-  const pathnames = [...block.querySelectorAll('a')].map((a) => new URL(a.href).pathname);
-  const results = await filterResults(pathnames);
-  block.textContent = '';
-  const ul = document.createElement('ul');
-  results.forEach((app) => {
-    ul.append(createAppCard(app, blockName));
+export async function filterApps(config, feed, limit, offset) {
+  const result = [];
+
+  /* filter apps by discoverApps, level etc. */
+  const filters = {};
+  Object.keys(config).forEach((key) => {
+    const filterNames = ['discoverApps', 'level'];
+    if (filterNames.includes(key)) {
+      const vals = config[key];
+      if (vals) {
+        let v = vals;
+        if (!Array.isArray(vals)) {
+          v = [vals];
+        }
+        filters[key] = v.map((e) => e.toLowerCase().trim());
+      }
+    }
   });
-  block.append(ul);
+
+  /* sort options */
+  config.sortBy = toCamelCase(config.sortBy);
+  const levels = ['pro', 'elite', 'bamboohr'];
+  const sorts = {
+    name: (a, b) => a.title.localeCompare(b.title),
+    level: (a, b) => levels.indexOf(toClassName(b.level)) - levels.indexOf(toClassName(a.level)),
+  };
+
+  await lookupPages([], 'marketplace');
+  const index = [...window.pageIndex.marketplace.data];
+  if (sorts[config.sortBy]) index.sort(sorts[config.sortBy]);
+
+  while ((feed.data.length < limit + offset) && (!feed.complete)) {
+    // eslint-disable-next-line no-await-in-loop
+    const indexChunk = index.slice(feed.cursor);
+
+    /* filter and ignore if already in result */
+    const feedChunk = indexChunk.filter((app) => {
+      const matchedAll = Object.keys(filters).every((key) => {
+        const matchedFilter = filters[key].some((val) => (app[key]
+          && app[key].toLowerCase().includes(val)));
+        return matchedFilter;
+      });
+      return (matchedAll && !result.includes(app));
+    });
+    feed.cursor = index.length;
+    feed.complete = true;
+    feed.data = [...feed.data, ...feedChunk];
+  }
+}
+
+async function decorateAppsFeed(
+  appsFeedEl,
+  config,
+  offset = 0,
+  feed = { data: [], complete: false, cursor: 0 },
+) {
+  let ul = appsFeedEl.querySelector('.apps-cards-feed');
+  if (!ul) {
+    ul = document.createElement('ul');
+    ul.className = 'apps-cards-feed';
+    appsFeedEl.appendChild(ul);
+  }
+
+  const limit = +config.limit || 12;
+  const pageEnd = offset + limit;
+  await filterApps(config, feed, limit, offset);
+  const apps = feed.data;
+  const max = pageEnd > apps.length ? apps.length : pageEnd;
+
+  for (let i = offset; i < max; i += 1) {
+    const app = apps[i];
+    ul.append(createAppCard(app, 'app-cards'));
+  }
+
+  /* add load more if needed */
+  if (apps.length > pageEnd || !feed.complete) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'load-more-wrapper';
+    const loadMore = document.createElement('a');
+    loadMore.className = 'load-more button small light';
+    loadMore.href = '#';
+    loadMore.textContent = 'Load More';
+    wrapper.append(loadMore);
+    appsFeedEl.append(wrapper);
+    loadMore.addEventListener('click', (event) => {
+      event.preventDefault();
+      loadMore.remove();
+      decorateAppsFeed(appsFeedEl, config, pageEnd, feed);
+    });
+  }
+}
+
+export default async function decorate(block, blockName) {
+  if (block.querySelector('a')) {
+    const pathnames = [...block.querySelectorAll('a')].map((a) => new URL(a.href).pathname);
+    const results = await lookupPages(pathnames);
+    block.textContent = '';
+    const ul = document.createElement('ul');
+    results.forEach((app) => {
+      ul.append(createAppCard(app, blockName));
+    });
+    block.append(ul);
+  } else {
+    const blockConfig = readBlockConfig(block);
+
+    /* camelCase config */
+    const config = {};
+    Object.keys(blockConfig).forEach((key) => { config[toCamelCase(key)] = blockConfig[key]; });
+
+    block.innerHTML = '';
+    await decorateAppsFeed(block, config);
+  }
 }

--- a/blog/blocks/app-cards/app-cards.js
+++ b/blog/blocks/app-cards/app-cards.js
@@ -118,7 +118,7 @@ async function decorateAppsFeed(
 export default async function decorate(block, blockName) {
   if (block.querySelector('a')) {
     const pathnames = [...block.querySelectorAll('a')].map((a) => new URL(a.href).pathname);
-    const results = await lookupPages(pathnames);
+    const results = await lookupPages(pathnames, 'marketplace');
     block.textContent = '';
     const ul = document.createElement('ul');
     results.forEach((app) => {

--- a/blog/blocks/article-feed/article-feed.js
+++ b/blog/blocks/article-feed/article-feed.js
@@ -1,9 +1,9 @@
 import {
-  lookupArticles,
+  lookupPages,
   readBlockConfig,
 } from '../../scripts/scripts.js';
 
-import { createCard } from '../featured-articles/featured-articles.js';
+import { createBlogCard } from '../featured-articles/featured-articles.js';
 
 function isCardOnPage(article) {
   const path = article.path.split('.')[0];
@@ -31,8 +31,8 @@ export async function filterArticles(config, feed, limit, offset) {
     }
   });
 
-  await lookupArticles([]);
-  const index = window.pageIndex;
+  await lookupPages([], 'blog');
+  const index = window.pageIndex.blog;
 
   while ((feed.data.length < limit + offset) && (!feed.complete)) {
     // eslint-disable-next-line no-await-in-loop
@@ -74,7 +74,7 @@ async function decorateArticleFeed(
   const max = pageEnd > articles.length ? articles.length : pageEnd;
   for (let i = offset; i < max; i += 1) {
     const article = articles[i];
-    cards.push(createCard(article, 'article-feed').outerHTML);
+    cards.push(createBlogCard(article, 'article-feed').outerHTML);
   }
 
   const cardGrid = document.createElement('div');

--- a/blog/blocks/featured-articles/featured-articles.js
+++ b/blog/blocks/featured-articles/featured-articles.js
@@ -1,10 +1,10 @@
 import {
-  lookupArticles,
+  lookupPages,
   createOptimizedPicture,
   toCategory,
 } from '../../scripts/scripts.js';
 
-export function createCard(article, classPrefix, eager = false) {
+export function createBlogCard(article, classPrefix, eager = false) {
   const title = article.title.split(' - ')[0];
   const card = document.createElement('div');
   card.className = `${classPrefix}-card`;
@@ -44,7 +44,7 @@ export default async function decorate(block) {
       // handle straight link
       const { pathname } = new URL(content.querySelector('a').href);
       // eslint-disable-next-line no-await-in-loop
-      const articles = await lookupArticles([pathname]);
+      const articles = await lookupPages([pathname], 'blog');
       if (articles.length) {
         const [article] = articles;
         if (i === 0) document.body.classList.add(`category-${toCategory(article.category)}`);
@@ -52,7 +52,7 @@ export default async function decorate(block) {
           article.noCategoryLink = true;
           article.category = category;
         }
-        const card = createCard(article, 'featured-articles', i === 0);
+        const card = createBlogCard(article, 'featured-articles', i === 0);
         contents.push(card.outerHTML);
       }
     } else {

--- a/blog/blocks/related-posts/related-posts.js
+++ b/blog/blocks/related-posts/related-posts.js
@@ -1,6 +1,6 @@
-import { getMetadata, lookupArticles } from '../../scripts/scripts.js';
+import { getMetadata, lookupPages } from '../../scripts/scripts.js';
 import { filterArticles } from '../article-feed/article-feed.js';
-import { createCard } from '../featured-articles/featured-articles.js';
+import { createBlogCard } from '../featured-articles/featured-articles.js';
 
 export default async function decorate(block) {
   const pathnames = [...block.querySelectorAll('a')].map((a) => {
@@ -9,13 +9,13 @@ export default async function decorate(block) {
     return pathname;
   });
   block.textContent = '';
-  let articles = await lookupArticles(pathnames);
+  let articles = await lookupPages(pathnames, 'blog');
   if (!articles.length) {
     const feed = { data: [], complete: false, cursor: 0 };
     await filterArticles({ category: getMetadata('category') }, feed, 4, 0);
     articles = feed.data.slice(0, 4);
   }
   articles.forEach((article) => {
-    block.append(createCard(article, 'related-posts'));
+    block.append(createBlogCard(article, 'related-posts'));
   });
 }

--- a/blog/blocks/search/search.css
+++ b/blog/blocks/search/search.css
@@ -13,26 +13,102 @@ main .search-results {
     flex-wrap: wrap;
     max-width: 1200px;
     margin: auto;
+    padding-top: 32px;
 }
 
-main .search-card {
+main .search-results > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-gap: 32px;
+}
+
+main .search-results .search-app-card {
+  box-shadow: 0 26px 52px -35px rgb(31 38 23 / 50%);
+  background-color: white;
+  border-radius: 15px;
+}
+
+
+/* app cards */
+
+.search-app-card-body {
+  margin: 16px;
+}
+
+.search-app-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.search-app-card-image {
+  line-height: 0;
+}
+
+.search-app-card-image img {
+  width: 100%;
+  aspect-ratio: 2 / 1;
+  object-fit: cover;
+  border-radius: 15px 15px 0 0;
+}
+
+.search-app-card-header h4 {
+  margin: 0;
+}
+
+.search-app-card-body > *:first-child {
+  margin-top: 0;
+}
+
+.search-app-card-search-tags span {
+  display: none;
+}
+
+.search-app-card-search-tags {
+  padding-top: 16px;
+}
+
+.search-app-card-search-tags span.search-searchtag-highlighted {
+  display: unset;
+  border: 2px solid var(--color-info-accent);
+  background-color: var(--color-info-accent);
+  margin-right: 4px;
+  margin-bottom: 4px;
+  white-space: nowrap;
+  color: white;
+  border-radius: 15px;
+  padding: 3px 8px;
+  font-size: var(--body-font-size-xs);
+  cursor: pointer;
+}
+
+.search-app-card-search-tags span.search-searchtag-highlighted .search-highlight {
+  font-weight: 600;
+  background-color: var(--color-info-accent-down);
+}
+
+/* blog cards */
+main .search-blog-card {
     width: 100%;
     box-sizing: border-box;
     padding: 10px;
     font-size: 15px;
 }
 
-main .search-card .search-card-picture {
+main .search-blog-card .search-blog-card-picture {
   margin-bottom: 25px;
 }
 
-main .search-card img {
+main .search-blog-card img {
   width: 100%;
   box-shadow: 0 30px 60px -40px rgb(31 38 23 / 50%);
   border-radius: 15px;
 }
 
-main .search-card h3 {
+main .search-blog-card h3 {
   font-family: var(--heading-font-family);
   font-size: 18px;
   font-weight: 600;
@@ -40,7 +116,7 @@ main .search-card h3 {
   margin: 0 0 20px;
 }
 
-main .search-card .search-card-readtime::before {
+main .search-blog-card .search-blog-card-readtime::before {
   content: '•';
   display: inline-block;
   margin: 1px 8px 0 4px;
@@ -48,16 +124,16 @@ main .search-card .search-card-readtime::before {
   vertical-align: top;
 }
 
-main .search-card-header a:any-link {
+main .search-blog-card-header a:any-link {
   color: inherit;
   text-decoration: inherit;
 }
 
-main .search-card .search-card-readtime:empty::before {
+main .search-blog-card .search-blog-card-readtime:empty::before {
   display: none;
 }
 
-main .search-card-body a:any-link{
+main .search-blog-card-body a:any-link{
   position: relative;
   font-weight: 700;
   text-decoration: none;
@@ -66,7 +142,7 @@ main .search-card-body a:any-link{
   font-size: 15px;
 }
 
-main .search-card-body a:any-link::after {
+main .search-blog-card-body a:any-link::after {
   content: "";
   border: solid var(--heading-color);
   border-width: 0 2.5px 2.5px 0;
@@ -78,7 +154,7 @@ main .search-card-body a:any-link::after {
   right: -20px;
 }
 
-main .search-card-header {
+main .search-blog-card-header {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 3px;
@@ -106,13 +182,14 @@ main .search .search-box {
 }
 
 @media (min-width: 600px) {
-  main .search-card {
+  main .search-blog-card {
       width: 50%;
   }
 }
 
 @media (min-width: 900px) {
-  main .search-card {
+  main .search-blog-card {
       width: 25%;
   }
 }
+

--- a/blog/blocks/search/search.css
+++ b/blog/blocks/search/search.css
@@ -25,14 +25,14 @@ main .search-results > ul {
   grid-gap: 32px;
 }
 
+
+/* app cards */
+
 main .search-results .search-app-card {
   box-shadow: 0 26px 52px -35px rgb(31 38 23 / 50%);
   background-color: white;
   border-radius: 15px;
 }
-
-
-/* app cards */
 
 .search-app-card-body {
   margin: 16px;
@@ -180,16 +180,3 @@ main .search .search-box {
     margin: auto;
     text-align: center;
 }
-
-@media (min-width: 600px) {
-  main .search-blog-card {
-      width: 50%;
-  }
-}
-
-@media (min-width: 900px) {
-  main .search-blog-card {
-      width: 25%;
-  }
-}
-

--- a/blog/blocks/search/search.js
+++ b/blog/blocks/search/search.js
@@ -1,5 +1,6 @@
-import { lookupPages } from '../../scripts/scripts.js';
+import { getMetadata, lookupPages } from '../../scripts/scripts.js';
 import { createBlogCard } from '../featured-articles/featured-articles.js';
+import { createAppCard } from '../app-cards/app-cards.js';
 
 function highlightTextElements(terms, elements) {
   elements.forEach((e) => {
@@ -23,21 +24,41 @@ function highlightTextElements(terms, elements) {
           markedUp += text.substring(hit.offset + hit.terms.length, matches[i + 1].offset);
         }
       });
+      if (e.closest('span') && terms) e.closest('span').classList.add('search-searchtag-highlighted');
       e.innerHTML = markedUp;
     }
   });
 }
 
 async function displaySearchResults(terms, results) {
-  await lookupPages([], 'blog');
-  const allPages = window.pageIndex.blog.data;
-  results.textContent = '';
+  let collection = 'blog';
+  if (getMetadata('theme') === 'marketplace') collection = 'marketplace';
+  await lookupPages([], collection);
+  const allPages = window.pageIndex[collection].data;
+  if (collection === 'marketplace') {
+    allPages.forEach((page) => {
+      page.searchTags = `${page.level}, ${page.listingType}, ${page.category}, ${page.subCategory}, ${page.discoverApps}`;
+    });
+  }
+  results.innerHTML = '<ul></ul>';
+  const ul = results.children[0];
   const filtered = allPages.filter((e) => e.title.toLowerCase().includes(terms.toLowerCase())
-    || e.description.toLowerCase().includes(terms.toLowerCase()));
+    || e.description.toLowerCase().includes(terms.toLowerCase())
+    || e.searchTags.toLowerCase().includes(terms.toLowerCase()));
   filtered.forEach((row) => {
-    results.append(createBlogCard(row, 'search'));
+    let card;
+    if (collection === 'blog') card = createBlogCard(row, 'search-blog');
+    if (collection === 'marketplace') card = createAppCard(row, 'search-app');
+    ul.append(card);
   });
-  highlightTextElements(terms, results.querySelectorAll('h3, p:first-of-type'));
+  highlightTextElements(terms, results.querySelectorAll('h3, p:first-of-type, span'));
+  results.querySelectorAll(('span.search-searchtag-highlighted')).forEach((span) => {
+    span.addEventListener('click', () => {
+      const searchBox = results.closest('.block').querySelector('#search-box');
+      searchBox.value = span.textContent;
+      displaySearchResults(searchBox.value.toLowerCase(), results);
+    });
+  });
 }
 
 export default async function decorate(block) {
@@ -46,6 +67,6 @@ export default async function decorate(block) {
   const searchBox = block.querySelector('#search-box');
   const results = block.querySelector('.search-results');
   searchBox.addEventListener('input', () => {
-    displaySearchResults(searchBox.value, results);
+    displaySearchResults(searchBox.value.toLowerCase(), results);
   });
 }

--- a/blog/blocks/search/search.js
+++ b/blog/blocks/search/search.js
@@ -35,11 +35,16 @@ async function displaySearchResults(terms, results) {
   if (getMetadata('theme') === 'marketplace') collection = 'marketplace';
   await lookupPages([], collection);
   const allPages = window.pageIndex[collection].data;
-  if (collection === 'marketplace') {
-    allPages.forEach((page) => {
-      page.searchTags = `${page.level}, ${page.listingType}, ${page.category}, ${page.subCategory}, ${page.discoverApps}`;
-    });
-  }
+  allPages.forEach((page) => {
+    let searchTags = '';
+    if (collection === 'marketplace') {
+      searchTags = `${page.level}, ${page.listingType}, ${page.category}, ${page.subCategory}, ${page.discoverApps}`;
+    }
+    if (collection === 'blog') {
+      searchTags = `${page.tags}`;
+    }
+    page.searchTags = searchTags;
+  });
   results.innerHTML = '<ul></ul>';
   const ul = results.children[0];
   const filtered = allPages.filter((e) => e.title.toLowerCase().includes(terms.toLowerCase())

--- a/blog/blocks/search/search.js
+++ b/blog/blocks/search/search.js
@@ -1,5 +1,5 @@
-import { lookupArticles } from '../../scripts/scripts.js';
-import { createCard } from '../featured-articles/featured-articles.js';
+import { lookupPages } from '../../scripts/scripts.js';
+import { createBlogCard } from '../featured-articles/featured-articles.js';
 
 function highlightTextElements(terms, elements) {
   elements.forEach((e) => {
@@ -29,13 +29,13 @@ function highlightTextElements(terms, elements) {
 }
 
 async function displaySearchResults(terms, results) {
-  await lookupArticles([]);
-  const allPages = window.pageIndex.data;
+  await lookupPages([], 'blog');
+  const allPages = window.pageIndex.blog.data;
   results.textContent = '';
   const filtered = allPages.filter((e) => e.title.toLowerCase().includes(terms.toLowerCase())
     || e.description.toLowerCase().includes(terms.toLowerCase()));
   filtered.forEach((row) => {
-    results.append(createCard(row, 'search'));
+    results.append(createBlogCard(row, 'search'));
   });
   highlightTextElements(terms, results.querySelectorAll('h3, p:first-of-type'));
 }

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -727,23 +727,29 @@ function buildImageBlocks(main) {
   });
 }
 
-export async function lookupArticles(pathnames) {
-  if (!window.pageIndex) {
-    const resp = await fetch('/blog/fixtures/blog-query-index.json');
+export async function lookupPages(pathnames, collection) {
+  const indexPaths = {
+    blog: '/blog/fixtures/blog-query-index.json',
+    marketplace: '/marketplace/query-index.json',
+  };
+  const indexPath = indexPaths[collection];
+  window.pageIndex = window.pageIndex || {};
+  if (!window.pageIndex[collection]) {
+    const resp = await fetch(indexPath);
     const json = await resp.json();
     const lookup = {};
     json.data.forEach((row) => {
       lookup[row.path] = row;
     });
-    window.pageIndex = { data: json.data, lookup };
+    window.pageIndex[collection] = { data: json.data, lookup };
   }
 
   /* guard for legacy URLs */
   pathnames.forEach((path, i) => {
     if (path.endsWith('/')) pathnames[i] = path.substr(0, path.length - 1);
   });
-
-  const result = pathnames.map((path) => window.pageIndex.lookup[path]).filter((e) => e);
+  const { lookup } = window.pageIndex[collection];
+  const result = pathnames.map((path) => lookup[path]).filter((e) => e);
   return (result);
 }
 

--- a/blog/styles/styles.css
+++ b/blog/styles/styles.css
@@ -36,7 +36,7 @@
   --color-brand-title: #000B1D;
   --color-info-accent: #73c41d;
   --color-info-accent-hover: #73c41d;
-  --color-info-accent-down: #73c41d;
+  --color-info-accent-down: #80d32c;
   --color-info-accent-light: #DEDEF9;
 
   /* body */


### PR DESCRIPTION
in preparation for https://github.com/hlxsites/bamboohr-website/issues/31 and https://github.com/hlxsites/bamboohr-website/issues/33 this PR allows for a more general handling of the search index loaded with the introduction of a search `collection` currently known collections are `blog` and `marketplace` but may likely become more...
as there was some overlap there is also an `app-cards` block has also been added...

see...
https://uncled-search-refactor--bamboohr-website--hlxsites.hlx.page/marketplace/
https://uncled-search-refactor--bamboohr-website--hlxsites.hlx.page/marketplace/all-apps

regression check:
https://uncled-search-refactor--bamboohr-website--hlxsites.hlx.live/blog/
also, try `search`
