### PR TITLE
Styles and functionality for new design/CompStrat page Quotes

### DIFF
--- a/blog/blocks/quote/quote.css
+++ b/blog/blocks/quote/quote.css
@@ -20,7 +20,7 @@ main .quote {
 	main .quote {
 		width: 250px;
 	}
-	
+
 	main .quote.left {
 		border-right: 2px solid var(--category-color);
 		border-left: none;
@@ -34,11 +34,12 @@ main .quote {
 		margin-left: 50px;
 	}
 }
+
 @media (min-width: 1200px) {
 	main .quote {
 		width: 400px;
 	}
-	
+
 	main .quote.left {
 		margin-left: -200px;
 	}
@@ -46,4 +47,198 @@ main .quote {
 	main .quote.right {
 		margin-right: -200px;
 	}
+}
+
+/* Cols/Widths */
+main .quote.full > div {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	margin-top: 1.25rem;
+}
+
+main .quote.full .image,
+main .quote.full .content {
+	flex: 1 0 0;
+}
+
+@media (max-width: 1024px) {
+	main .quote.full .image {
+		order: 1;
+	}
+
+	main .quote.full .content {
+		order: 2;
+	}
+}
+
+@media (min-width: 1025px) {
+	main .quote.full > div {
+		flex-direction: revert;
+		gap: 2rem;
+	}
+}
+
+main .quote.full.image-130 .image {
+	max-width: 8.125rem;
+}
+
+main .quote.full.image-200 .image {
+	max-width: 12.5rem;
+}
+
+main .quote.full.image-420 .image {
+	max-width: 26.25rem;
+}
+
+/* Colors */
+main .quote.full {
+	background-clip: revert;
+	/* stylelint-disable-next-line property-no-vendor-prefix */
+	-webkit-background-clip: revert;
+	/* stylelint-disable-next-line property-no-vendor-prefix */
+	-moz-background-clip: revert;
+	background-image: none;
+	border: 0;
+	font-family: var(--body-font-family);
+	font-size: 1.125rem;
+	font-style: normal;
+	font-weight: 500;
+	line-height: 1.5;
+	margin: 0;
+	padding: 0;
+	text-align: center;
+	-webkit-text-fill-color: revert;
+	width: auto;
+}
+
+@media (min-width: 600px) {
+	main .quote.full {
+		font-size: 1.375rem;
+		line-height: 1.7272;
+	}
+}
+
+@media (min-width: 1025px) {
+	main .quote.full {
+		font-size: 1.625rem;
+		line-height: 1.4615;
+		text-align: revert;
+	}
+}
+
+main .quote.full [data-align="center"] {
+	text-align: center;
+}
+
+main .quote.full [data-align="center"] picture {
+	margin: 0 auto;
+}
+
+main .quote.full a:not(.button),
+main .quote.full strong {
+	font-weight: var(--heading-font-weight);
+}
+
+main .quote.full .byline {
+	font-family: var(--body-font-family);
+	font-size: 1rem;
+	font-weight: var(--heading-font-weight);
+	letter-spacing: .125rem;
+	line-height: 1.5;
+	text-transform: uppercase;
+}
+
+@media (min-width: 1025px) {
+	main .quote.full .button-container {
+		text-align: left;
+	}
+}
+
+main .quote.full .button {
+	border-radius: 1.875rem;
+	color: var(--color-white);
+	font-family: var(--body-font-family);
+	font-size: .9375rem;
+	font-weight: var(--heading-font-weight);
+	letter-spacing: 0.0312rem;
+	line-height: 1.3333;
+	margin: 0;
+	padding: .625rem 1.875rem;
+	white-space: revert;
+}
+
+/* Blue */
+main .quote.blue {
+	color: var(--color-5-shade-5);/* TODO: needs theme replacement */
+}
+
+main .quote.blue a:not(.button),
+main .quote.blue strong {
+	background-image: linear-gradient(rgb(0 0 0 / 0%) 50%, var(--color-5-tint-10) 0);/* TODO: needs theme replacement */
+	color: var(--color-5-shade-5);/* TODO: needs theme replacement */
+}
+
+main .quote.blue .byline {
+	color: var(--color-gray-12);/* TODO: needs theme replacement */
+}
+
+main .quote.blue .button {
+	background-image: linear-gradient(90deg, var(--color-5-shade-5) 0%, var(--color-5-shade-10) 100%);/* TODO: needs theme replacement */
+}
+
+/* Green */
+main .quote.green {
+	color: var(--color-1-shade-5);/* TODO: needs theme replacement */
+}
+
+main .quote.green a:not(.button),
+main .quote.green strong {
+	background-image: linear-gradient(rgb(0 0 0 / 0%) 50%, var(--color-1-tint-10) 0);/* TODO: needs theme replacement */
+	color: var(--color-1-shade-5);/* TODO: needs theme replacement */
+}
+
+main .quote.green .byline {
+	color: var(--color-gray-10);/* TODO: needs theme replacement */
+}
+
+main .quote.green .button {
+	background-image: linear-gradient(90deg, var(--color-1-shade-5) 0%, var(--color-1-shade-10) 100%);/* TODO: needs theme replacement */
+}
+
+/* Hero */
+main .quote.hero {
+	background-clip: revert;
+	/* stylelint-disable-next-line property-no-vendor-prefix */
+	-webkit-background-clip: revert;
+	/* stylelint-disable-next-line property-no-vendor-prefix */
+	-moz-background-clip: revert;
+	background-image: none;
+	border: 0;
+	color: var(--color-white);
+	font-family: var(--stylized-font-family);
+	font-size: 2.5rem;
+	font-style: normal;
+	font-weight: var(--body-font-weight);
+	line-height: 1.35;
+	margin: 0;
+	padding: 0;
+	-webkit-text-fill-color: revert;
+	width: auto;
+}
+
+main .quote.hero .byline {
+	color: var(--color-white);
+	font-family: var(--body-font-family);
+	font-size: 1rem;
+	font-weight: var(--heading-font-weight);
+	letter-spacing: .125rem;
+	line-height: 1.5;
+	text-transform: uppercase;
+}
+
+/* TODO: just to show update */
+.temp-bg-green {
+	background-image: linear-gradient(90deg, var(--color-1-shade-5) 0%, var(--color-1-shade-10) 100%);/* TODO: needs theme replacement? */
 }

--- a/blog/blocks/quote/quote.js
+++ b/blog/blocks/quote/quote.js
@@ -1,0 +1,12 @@
+export default function decorate(block) {
+  const byline = block.querySelector('em');
+
+  // Adding image class to block children
+  [...block.children].forEach((row) => [...row.children].forEach((cell) => cell.classList.add(cell.querySelector('img') ? 'image' : 'content')));
+
+  // if byline
+  if (byline) {
+    byline.parentNode.classList.add('byline');
+    byline.parentNode.textContent = byline.textContent;
+  }
+}

--- a/blog/styles/lazy-styles.css
+++ b/blog/styles/lazy-styles.css
@@ -5,6 +5,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,500;0,600;0,700;0,800;0,900;1,500;1,600;1,700;1,800;1,900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Permanent+Marker:wght@400;700&display=swap');
 
 /* icons */
 

--- a/blog/styles/styles.css
+++ b/blog/styles/styles.css
@@ -95,6 +95,9 @@
   --heading-color: var(--color-gray-12);
   --heading-font-family: 'Fira Sans', 'Trebuchet', sans-serif;
 
+  /* stylized font */
+  --stylized-font-family: 'Permanent Marker', sans-serif;
+
   /* box-shadow */
   --box-shadow-1: 0 2px 5px 0 rgb(0 0 0 / 20%);
   --box-shadow-2: 0 30px 60px -40px rgb(31 38 23 / 50%);
@@ -354,7 +357,7 @@ main .columns ul li::before {
   top: 5px;
   left: 0;
   background-image: var(--bullet-level1-gray);
-  background-repeat: no-repeat; 
+  background-repeat: no-repeat;
   background-position: center;
   width: 16px;
   height: 18px;
@@ -1003,15 +1006,15 @@ main .default-content-wrapper p a.button:any-link {
     width: 1200px;
     max-width: 100%;
     margin: 0 auto;
-    display: grid; 
-    grid-template-columns: 368px calc(100% - 368px); 
+    display: grid;
+    grid-template-columns: 368px calc(100% - 368px);
     grid-template-rows: repeat(3, auto) 1fr;
     /* stylelint-disable-next-line */
-    grid-template-areas: 
+    grid-template-areas:
       'header header'
       'carousel carousel'
       'links tabs'
-      'details tabs'; 
+      'details tabs';
     }
 
   .marketplace-listing .listing-header-container {


### PR DESCRIPTION
Adding "Permanent Marker" font for `hero` quote style

Ticket [ZZ-878](https://bamboohr.atlassian.net/browse/ZZ-878)

Test URLs:
- Before: https://main--bamboohr-website--hlxsites.hlx.page/drafts/hoodoo/quotes
- After: https://jwetmore-zz878-quote--bamboohr-website--hlxsites.hlx.page/drafts/hoodoo/quotes

Content:
- https://docs.google.com/document/d/1sD-WBo94SQJ8w-7mgNLTJOCMpmsVirJY4Uhwx6p6cPg/edit#

Notes:
- The block wrappers are all `max-width: 800px;` from this selector: `main .section > div` and I figure overall content width is being handled in a global task? Anyway, things are a bit scrunched because of that, so in testing, I overrode those to 1160px to match the design
- I don't know how theme colors will work, so there's `blue` and `green` modifiers currently. Happy to change that if given guidance ;)
- The `hero` variation is on a temp section metadata style so it can be seen, but will ultimately be dropped into that block
- The image on one quote example is actually a background absolutely positioned, so I didn't include that image since it's being handled elsewhere