### PR TITLE
Adding sass support and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ npm i
 npm tst
 ```
 
+## Run sass auto-compile and Helix Pages
+
+```sh
+npm run up
+```
+
+The above command will run `node sass-compile.js` in parallel with `hlx up` which will start your local Helix Pages development environment.
+
+### Note on SASS usage and Helix Local Development
+
+ The `npm run up` will parse the `styles` and `blocks` directory for any `.scss` files. Files that are found will be compiled to css and saved in the same location and name with a `.css` extension. It will then continue to watch for changes to `.scss` files and will compile to their associated CSS files on changes.
+
+Examples: 
+  - `{repo}/blocks/header/header.scss` will compile to `{repo}/blocks/header/header.css`
+  - `{repo}/styles/style.scss` will compile to `{repo}/styles/styles.css`
+
+As both `sass-compile.js` and `hlx up` are watching for changes, changes made to your sass files while using the `rpm run up` command will be reflected automatically in your localhost. 
+
+Note that using only the `hlx up` command will not trigger updates on-change for sass files.
+
 ## Local development
 
 1. Create a new repository based on the `helix-project-boilerplate` template and add a mountpoint in the `fstab.yaml`

--- a/blog/blocks/page-header/page-header.scss
+++ b/blog/blocks/page-header/page-header.scss
@@ -1,0 +1,89 @@
+main {
+    .page-header-container>div {
+        max-width: unset;
+        margin: 0 auto;
+        padding: 0;
+    }
+
+    .page-header {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        width: 100%;
+        height: 450px;
+
+        >div {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        .page-header-image {
+            position: absolute;
+            top: 0;
+            width: 100%;
+            max-width: unset;
+            height: 450px;
+            padding: 0;
+            background-image: url('../../styles/single-post-leaf.png');
+            background-position: bottom;
+            background-repeat: no-repeat;
+            background-size: contain;
+        }
+
+        picture {
+            box-sizing: border-box;
+            position: absolute;
+            z-index: -1;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            object-fit: cover;
+        }
+
+        img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .page-header-title, .page-header-title h1, .page-header-subtitle {
+            margin: 0 auto;
+            color: var(--color-white);
+            font-style: unset;
+            text-align: center;
+        }
+
+        .page-header-subtitle {
+            margin-top: 20px;
+            font-size: 18px;
+            font-weight: 700;
+            line-height: 26px;
+        }
+
+        @media (min-width: 900px) {
+            box-sizing: border-box;
+            justify-content: flex-start;
+            height: 430px;
+            padding-top: 106px;
+
+            .page-header-image {
+                background-size: 100% 105px;
+            }
+
+            .page-header-subtitle {
+                margin-top: 30px;
+                font-size: 21px;
+                line-height: 28px;
+            }
+        }
+
+        @media (min-width: 1200px) {
+            >div {
+                max-width: 1200px;
+            }
+        }
+    }
+}

--- a/blog/blocks/quote/quote.scss
+++ b/blog/blocks/quote/quote.scss
@@ -1,0 +1,50 @@
+main .quote {
+	font-family: var(--heading-font-family);
+	background: var(--category-quote-bg);
+  	background-clip: text;
+	/* stylelint-disable-next-line property-no-vendor-prefix */
+	-webkit-background-clip: text;
+	/* stylelint-disable-next-line property-no-vendor-prefix */
+	-moz-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	margin: 35px 0;
+	padding: 10px 0 10px 32px;
+	border-left: 2px solid var(--category-color);
+	font-size: 20px;
+	line-height: 28px;
+	font-weight: 600;
+	font-style: italic;
+}
+
+@media (min-width: 600px) {
+	main .quote {
+		width: 250px;
+
+        &.left {
+            border-right: 2px solid var(--category-color);
+            border-left: none;
+            padding: 10px 32px 10px 0;
+            float: left;
+            margin-right: 50px;
+        }
+
+        &.right {
+            float: right;
+            margin-left: 50px;
+        }
+	}
+}
+
+@media (min-width: 1200px) {
+	main .quote {
+		width: 400px;
+
+        &.left {
+            margin-left: -200px;
+        }
+
+        &.right {
+            margin-right: -200px;
+        }
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint": "8.14.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
+        "sass": "^1.54.6",
         "sinon": "13.0.2",
         "stylelint": "14.8.0",
         "stylelint-config-prettier": "9.0.3",
@@ -3304,6 +3305,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "dev": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5493,6 +5500,23 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sass": {
+      "version": "1.54.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.6.tgz",
+      "integrity": "sha512-DUqJjR2WxXBcZjRSZX5gCVyU+9fuC2qDfFzoKX9rV4rCOcec5mPtEafTcfsyL3YJuLONjWylBne+uXVh5rrmFw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -9099,6 +9123,12 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "dev": true
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -10723,6 +10753,17 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass": {
+      "version": "1.54.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.6.tgz",
+      "integrity": "sha512-DUqJjR2WxXBcZjRSZX5gCVyU+9fuC2qDfFzoKX9rV4rCOcec5mPtEafTcfsyL3YJuLONjWylBne+uXVh5rrmFw==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:watch": "npm test -- --watch",
     "lint:js": "eslint .",
     "lint:css": "stylelint 'blog/blocks/**/*.css' 'blog/styles/*.css'",
-    "lint": "npm run lint:js && npm run lint:css"
+    "lint": "npm run lint:js && npm run lint:css",
+    "up": "node sass-compile.js & hlx up"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,7 @@
     "eslint": "8.14.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-import": "2.26.0",
+    "sass": "^1.54.6",
     "sinon": "13.0.2",
     "stylelint": "14.8.0",
     "stylelint-config-prettier": "9.0.3",

--- a/sass-compile.js
+++ b/sass-compile.js
@@ -1,0 +1,42 @@
+const sass = require('sass');
+const fs = require('fs');
+const path = require('path');
+const { readdir } = require('fs/promises');
+const { fileURLToPath } = require('url');
+
+// const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const compileAndSave = async (sassFile) => {
+    const dest = sassFile.replace(path.extname(sassFile), ".css");
+
+    fs.writeFile(dest, sass.compile(sassFile).css, (err) => {
+        if (err) console.log(err);
+        console.log(`Compiled ${sassFile} to ${dest}`);
+    });
+}
+
+const processFiles = async (parent) => {
+    let files = await readdir(parent, { withFileTypes: true});
+    for (const file of files) {
+        if (file.isDirectory()) {
+            await processFiles(path.join(parent, file.name));
+        }
+        if (path.extname(file.name) === '.scss') {
+            await compileAndSave(path.join(parent, file.name));
+        }
+    }
+}
+
+for (const folder of ["styles","blocks"]) {
+    try {
+        processFiles(path.join(__dirname, "blog", folder));
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+fs.watch('.', {recursive: true}, (eventType, fileName) => {
+    if (path.extname(fileName) === ".scss" && eventType === "change") {
+        compileAndSave(path.join(__dirname, fileName));
+    }
+})


### PR DESCRIPTION
Hi, 

I was speaking with David Nuescheler about a recent effort I made to incorporate SASS into helix builds, which I created a boilerplate fork here: [https://github.com/sachioross/helix-project-boilerplate-sass/](https://github.com/sachioross/helix-project-boilerplate-sass/). He mentioned that this team had mentioned using sass previously, so I thought I'd open a PR if you'd like to utilize sass in this project. 

**Notable changes:** 
- Use `npm run up` instead of `hlx up` because `npm run up` will ensure sass files are watched and compiled on save to their associated css file (this is noted in the updated readme)
- You do not need to have a sass file for each css file, but if there is one under the `/blocks` or `/styles` folder (in this case under `/blog/(blocks|styles)`), then it will compile to the associated css file on save.
- If you do create a sass file, please note that the associated css file will be overwritten, so from that point forward changes should only be made in the `scss` file (or, if you don't want it anymore, just delete the sass file). 
- The only additional dependency is the inclusion of the `sass` nodejs module, so you'll need to run `npm i` after pulling this change
- This has 0 impact on front-end delivery, as it's all back-end compilation and part of the dev process

For examples, I've added sass files for the following blocks: `page-header` and `quote`. 

If you have any questions, happy to help answer. And understand if you'd prefer not to merge.   

Test URLs:
- [https://main--bamboohr-website--dr-adobe.hlx.page/](https://main--bamboohr-website--dr-adobe.hlx.page/)
