### PR TITLE
Cards Refactor

### DIFF
--- a/blog/blocks/cards/cards.css
+++ b/blog/blocks/cards/cards.css
@@ -2,59 +2,49 @@
 
 /* using grid for better gap functionality */
 .cards {
+    --cols: 1;/* mobile: always 1-col */
     --gap: 2.5rem;
 
     display: grid;
     gap: var(--gap);
+    grid-template-columns: repeat(var(--cols), 1fr);
 }
 
 /* set better box sizing */
 .cards,
-.cards > * {
+.cards > *,
+.cards > *::before,
+.cards > *::after {
     box-sizing: border-box;
-}
-
-/* mobile: always 1-col */
-.cards.cols-1,
-.cards.cols-2,
-.cards.cols-3,
-.cards.cols-4,
-.cards.cols-5 {
-    --cols: 1;
-
-    grid-template-columns: repeat(var(--cols), 1fr);
 }
 
 /* tablet: always 2-col */
 @media (min-width: 600px) {
-    .cards.cols-1,
-    .cards.cols-2,
-    .cards.cols-3,
-    .cards.cols-4,
-    .cards.cols-5 {
+    /* no style-1-columns since default */
+
+    .cards.style-2-columns,
+    .cards.style-3-columns,
+    .cards.style-4-columns,
+    .cards.style-5-columns {
         --cols: 2;
     }
 }
 
 /* desktop: normal cols */
 @media (min-width: 1025px) {
-    .cards.cols-1 {
-        --cols: 1;
-    }
+    /* no style-1-columns since default */
 
-    .cards.cols-2 {
-        --cols: 2;
-    }
+    /* no style-2-columns since inherit from tablet */
 
-    .cards.cols-3 {
+    .cards.style-3-columns {
         --cols: 3;
     }
 
-    .cards.cols-4 {
+    .cards.style-4-columns {
         --cols: 4;
     }
 
-    .cards.cols-5 {
+    .cards.style-5-columns {
         --cols: 5;
     }
 
@@ -64,6 +54,7 @@
 /* default styles */
 .cards > .card {
     --padding: 0;
+    --spacing: 1rem;
 
     color: var(--color-gray-10);
     display: flex;
@@ -72,7 +63,7 @@
     font-size: 1.125rem;
     font-style: normal;
     font-weight: var(--body-font-weight);
-    gap: 1rem;
+    gap: var(--spacing);
     line-height: 1.5;
     padding: var(--padding);
 }
@@ -259,12 +250,12 @@
     box-shadow: var(--theme-shadow2-shade5);
 }
 
-/* "image top" styles */
-.cards.image-top > .card > .title {
+/* image styles */
+.cards > .card.has-image > .title {
     margin-top: .625rem;
 }
 
-.cards.image-top > .card > .image {
+.cards > .card.has-image > .image {
     border-radius: 1rem;
     box-shadow: var(--theme-shadow2-shade5);
     display: flex;

--- a/blog/blocks/cards/cards.js
+++ b/blog/blocks/cards/cards.js
@@ -1,10 +1,7 @@
 export default function decorate(block) {
-  const cards = block.querySelectorAll(':scope > div > div');
-  const cols = block.firstElementChild.children.length;
-  if (block.classList.contains('full-width')) block.parentElement.classList.add('full-width');
+  const cards = block.querySelectorAll(':scope > div');
 
-  // add grid cols class
-  block.classList.add(`cols-${cols}`);
+  if (block.classList.contains('full-width')) block.parentElement.classList.add('full-width');
 
   // convert "number" classes
   [...block.classList].forEach((name) => {
@@ -17,23 +14,38 @@ export default function decorate(block) {
   // empty block
   block.textContent = '';
   cards.forEach((card) => {
+    const contents = card.querySelectorAll(':scope > div');
     const icon = card.querySelector('span.icon');
+
+    // loop children
+    card.textContent = '';
+    contents.forEach((content) => {
+      const alignment = content.dataset.align;
+
+      // set alignment
+      if (alignment) card.dataset.align = alignment;
+
+      // pull everything into one div
+      [...content.children].forEach((element) => card.append(element));
+    });
+
     const image = card.querySelector('picture');
     const title = card.querySelector('h4');
 
-    if (image) {
-      image.classList.add('image');
-      card.prepend(image);
-    }
-
+    // move icon out of p
     if (icon) card.prepend(icon);
 
-    if (title) title.classList.add('title');
-
     // clear out empties
-    card.querySelectorAll(':scope > p').forEach((empty) => {
-      if (empty.textContent.trim() === '') empty.remove();
-    });
+    card.querySelectorAll(':scope > p:empty').forEach((empty) => empty.remove());
+
+    // add image classes
+    if (image) {
+      card.classList.add('has-image');
+      image.classList.add('image');
+    }
+
+    // add title class
+    if (title) title.classList.add('title');
 
     // add card to block
     card.classList.add('card');


### PR DESCRIPTION
Refactoring Cards to be one row per card when authoring for easier authorability

Ticket: [ZZ-1032](https://bamboohr.atlassian.net/browse/ZZ-1032)

Docs:
- Original: https://docs.google.com/document/d/16CqtoktOlqogN1d_hBqmVp7QYmjmdtWbOL56X__J_fE
- Refactor: https://docs.google.com/document/d/1Gr3aaafxD23RIda1l89jB-wPurLvikI7iRSHGhMX7O0

Test URLs:

**Original**
- Before: https://main--bamboohr-website--hlxsites.hlx.page/drafts/hoodoo/cards
- After: https://jwetmore-zz1032-cards-refactor--bamboohr-website--hlxsites.hlx.page/drafts/hoodoo/cards

**Refactor**
- Before (refactor): https://main--bamboohr-website--hlxsites.hlx.page/drafts/hoodoo/cards-refactor
- After (refactor): https://jwetmore-zz1032-cards-refactor--bamboohr-website--hlxsites.hlx.page/drafts/hoodoo/cards-refactor

Compare "Original - Before" against "Refactor - After" to see that output is the same.

**Notes**

The biggest change here is obviously changing the cards in the GDoc to be rows for each card, which should allow easier authoring.

There's also a smaller change with the former "image top" option... you no longer need the paren-class for it, since it's the only image option.

Finally, if you don't add a column paren-class, it assumes 1-col, I wasn't sure if we should pick a default. Or another possibility could be it assumes the row count is how many columns... either could be added fairly easily.