### PR TITLE
ZZ-978 Mobile menu underline styling fix

### DIFF
--- a/blog/blocks/header/header.css
+++ b/blog/blocks/header/header.css
@@ -5,7 +5,7 @@
   height: 18px;
   object-fit: contain;
   display: inline-block;
-  padding: 9px
+  padding: 9px;
 }
 
 .header-search {
@@ -77,23 +77,24 @@
   cursor: pointer;
 }
 
-.header-search-close::before, .header-search-close::after {
-    content: "";
-    display: block;
-    box-sizing: border-box;
-    position: absolute;
-    width: 21px;
-    height: 3px;
-    background: var(--color-white);
-    transform: rotate(45deg);
-    border-radius: 5px;
-    top: 8px;
-    left: 1px;
-    margin: 18px 16px;
+.header-search-close::before,
+.header-search-close::after {
+  content: "";
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  width: 21px;
+  height: 3px;
+  background: var(--color-white);
+  transform: rotate(45deg);
+  border-radius: 5px;
+  top: 8px;
+  left: 1px;
+  margin: 18px 16px;
 }
 
 .header-search-close::after {
-    transform: rotate(-45deg);
+  transform: rotate(-45deg);
 }
 
 /* header and nav layout */
@@ -105,7 +106,7 @@ header {
 
 header .nav {
   display: grid;
-  grid-template-areas: 'brand hamburger' 'sections sections' 'buttons buttons';
+  grid-template-areas: "brand hamburger" "sections sections" "buttons buttons";
   grid-template-columns: calc(100% - 22px) 22px;
   /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
   grid-template-rows: 64px 1fr;
@@ -130,9 +131,9 @@ header .nav-hamburger {
   color: var(--color-gray3);
 }
 
-header .nav[aria-expanded='false'] .nav-hamburger-icon,
-header .nav[aria-expanded='false'] .nav-hamburger-icon::after,
-header .nav[aria-expanded='false'] .nav-hamburger-icon::before {
+header .nav[aria-expanded="false"] .nav-hamburger-icon,
+header .nav[aria-expanded="false"] .nav-hamburger-icon::after,
+header .nav[aria-expanded="false"] .nav-hamburger-icon::before {
   box-sizing: border-box;
   position: relative;
   display: block;
@@ -143,18 +144,18 @@ header .nav[aria-expanded='false'] .nav-hamburger-icon::before {
   background: currentcolor;
 }
 
-header .nav[aria-expanded='false'] .nav-hamburger-icon::after,
-header .nav[aria-expanded='false'] .nav-hamburger-icon::before {
+header .nav[aria-expanded="false"] .nav-hamburger-icon::after,
+header .nav[aria-expanded="false"] .nav-hamburger-icon::before {
   content: "";
   position: absolute;
   top: -6px;
 }
 
-header .nav[aria-expanded='false'] .nav-hamburger-icon::after {
+header .nav[aria-expanded="false"] .nav-hamburger-icon::after {
   top: 6px;
 }
 
-header .nav[aria-expanded='true'] .nav-hamburger-icon {
+header .nav[aria-expanded="true"] .nav-hamburger-icon {
   box-sizing: border-box;
   position: relative;
   display: block;
@@ -165,8 +166,8 @@ header .nav[aria-expanded='true'] .nav-hamburger-icon {
   transform: translate(-3px, -2px);
 }
 
-header .nav[aria-expanded='true'] .nav-hamburger-icon::after,
-header .nav[aria-expanded='true'] .nav-hamburger-icon::before {
+header .nav[aria-expanded="true"] .nav-hamburger-icon::after,
+header .nav[aria-expanded="true"] .nav-hamburger-icon::before {
   content: "";
   display: block;
   box-sizing: border-box;
@@ -177,11 +178,11 @@ header .nav[aria-expanded='true'] .nav-hamburger-icon::before {
   transform: rotate(45deg);
   border-radius: 5px;
   top: 8px;
-  left: 1px
+  left: 1px;
 }
 
-header .nav[aria-expanded='true'] .nav-hamburger-icon::after {
-  transform: rotate(-45deg)
+header .nav[aria-expanded="true"] .nav-hamburger-icon::after {
+  transform: rotate(-45deg);
 }
 
 /* brand */
@@ -195,7 +196,7 @@ header .nav-brand {
   color: var(--color-1);
 }
 
-header .nav-brand a:any-link{
+header .nav-brand a:any-link {
   color: inherit;
   text-decoration: inherit;
 }
@@ -205,7 +206,7 @@ header .nav-brand p {
 }
 
 header .nav-brand:not(.simple) .icon::after {
-  content: '|';
+  content: "|";
   color: var(--color-1);
   margin: 0 10px;
 }
@@ -231,19 +232,19 @@ header .nav-sections {
 header .nav-sections ul {
   list-style: none;
   padding-left: 0;
-} 
+}
 
 header .nav-sections li {
   font-size: 20px;
   font-weight: 700;
 }
 
-header .nav[aria-expanded='true'] .nav-sections {
+header .nav[aria-expanded="true"] .nav-sections {
   display: block;
   align-self: flex-start;
 }
 
-header .nav[aria-expanded='true'] {
+header .nav[aria-expanded="true"] {
   min-height: 100vh;
 }
 
@@ -268,7 +269,7 @@ header .nav-section .nav-section-wrapper {
   transform: translate(0, -1000px);
 }
 
-header .nav-section ul a:any-link{
+header .nav-section ul a:any-link {
   text-decoration: none;
   color: var(--color-gray-8);
 }
@@ -284,31 +285,32 @@ header .nav-section li a:any-link {
   color: var(--color-gray-11);
 }
 
-header .nav-section[aria-expanded='true'] > ul,
-header .nav-section[aria-expanded='true'] > .nav-section-wrapper {
+header .nav-section[aria-expanded="true"] > ul,
+header .nav-section[aria-expanded="true"] > .nav-section-wrapper {
   position: relative;
   opacity: 1;
   max-height: 100vh;
   display: block;
   transform: unset;
-} 
+}
 
-header .nav-section > ul > *, header .nav-section > .nav-section-wrapper > * {
+header .nav-section > ul > *,
+header .nav-section > .nav-section-wrapper > * {
   opacity: 0;
 }
 
-header .nav-section[aria-expanded='true'] > ul > *, header .nav-section[aria-expanded='true'] > .nav-section-wrapper > * {
+header .nav-section[aria-expanded="true"] > ul > *,
+header .nav-section[aria-expanded="true"] > .nav-section-wrapper > * {
   opacity: 1;
 }
 
-header .nav-section[aria-expanded='true'] li[aria-expanded='true'] > ul {
+header .nav-section[aria-expanded="true"] li[aria-expanded="true"] > ul {
   position: relative;
   opacity: 1;
   max-height: 100vh;
   display: block;
   transform: unset;
 }
-
 
 /* nav buttons */
 
@@ -319,7 +321,7 @@ header .nav-buttons {
   width: 100%;
 }
 
-header .nav[aria-expanded='true'] .nav-buttons {
+header .nav[aria-expanded="true"] .nav-buttons {
   display: block;
   align-self: flex-start;
 }
@@ -377,15 +379,14 @@ header .nav-section.nav-section-subscribe form {
   position: relative;
 }
 
-
 /* desktop nav styles */
 
 @media (min-width: 1000px) {
   header .nav {
     overflow: unset;
-    grid-template-areas: 'brand sections buttons';
+    grid-template-areas: "brand sections buttons";
     grid-template-columns: 300px 1fr 250px;
-    background-color: var(--color-white)
+    background-color: var(--color-white);
   }
 
   header .nav.extra-buttons {
@@ -394,9 +395,8 @@ header .nav-section.nav-section-subscribe form {
 
   header .nav-brand p img {
     height: 23px;
-    padding-left: 22px
+    padding-left: 22px;
   }
-  
 
   header .nav-hamburger {
     display: none;
@@ -406,10 +406,10 @@ header .nav-section.nav-section-subscribe form {
     display: flex;
     flex-direction: row;
     background-color: unset;
-    width: unset;        
+    width: unset;
   }
-  
-  header .nav[aria-expanded='true'] .nav-sections {
+
+  header .nav[aria-expanded="true"] .nav-sections {
     display: flex;
     min-height: unset;
   }
@@ -443,7 +443,8 @@ header .nav-section.nav-section-subscribe form {
     color: var(--color-1);
   }
 
-  header .nav-section ul, header .nav-section .nav-section-wrapper {
+  header .nav-section ul,
+  header .nav-section .nav-section-wrapper {
     opacity: 0;
     padding-bottom: 30px;
     padding-top: 18px;
@@ -480,29 +481,32 @@ header .nav-section.nav-section-subscribe form {
     border-radius: 0 0 20px;
     height: 100%;
     box-sizing: border-box;
-    padding-top: 12px;  
+    padding-top: 12px;
     max-height: unset;
   }
 
-  header .nav-section[aria-expanded='true'] > ul, header .nav-section[aria-expanded='true'] > .nav-section-wrapper {
+  header .nav-section[aria-expanded="true"] > ul,
+  header .nav-section[aria-expanded="true"] > .nav-section-wrapper {
     position: absolute;
     opacity: 1;
     max-height: 100vh;
     display: block;
     transition: max-height 0.4s linear;
     transform: unset;
-  } 
+  }
 
-  header .nav-section > ul > *, header .nav-section > .nav-section-wrapper > * {
+  header .nav-section > ul > *,
+  header .nav-section > .nav-section-wrapper > * {
     opacity: 0;
     transition: opacity 0.6s linear;
   }
 
-  header .nav-section[aria-expanded='true'] > ul > *, header .nav-section[aria-expanded='true'] > .nav-section-wrapper > * {
+  header .nav-section[aria-expanded="true"] > ul > *,
+  header .nav-section[aria-expanded="true"] > .nav-section-wrapper > * {
     opacity: 1;
   }
 
-  header .nav-section[aria-expanded='true'] li[aria-expanded='true'] > ul {
+  header .nav-section[aria-expanded="true"] li[aria-expanded="true"] > ul {
     position: absolute;
     opacity: 1;
     left: 280px;
@@ -511,12 +515,12 @@ header .nav-section.nav-section-subscribe form {
     transform: unset;
   }
 
-  header .nav-section[aria-expanded='true'] li[aria-expanded='true'] {
+  header .nav-section[aria-expanded="true"] li[aria-expanded="true"] {
     color: var(--color-1);
   }
 
-  header .nav-section[aria-expanded='true'] li[aria-expanded='true']::after {
-    content: '❯';
+  header .nav-section[aria-expanded="true"] li[aria-expanded="true"]::after {
+    content: "❯";
     float: right;
   }
 
@@ -525,7 +529,7 @@ header .nav-section.nav-section-subscribe form {
     display: flex;
     width: 100vw;
   }
-  
+
   header .nav-buttons .button {
     padding: 5px 20px;
     min-width: 60px;
@@ -538,7 +542,7 @@ header .nav-section.nav-section-subscribe form {
     padding: 8px 20px;
     font-size: 12px;
     line-height: 15px;
-    letter-spacing: .5px;
+    letter-spacing: 0.5px;
     font-weight: 900;
     font-family: var(--body-font-family);
     border: solid 2px var(--color-1);
@@ -558,4 +562,3 @@ header .nav-section.nav-section-subscribe form {
     width: 500px;
   }
 }
-

--- a/blog/blocks/header/header.css
+++ b/blog/blocks/header/header.css
@@ -248,6 +248,10 @@ header .nav[aria-expanded="true"] {
   min-height: 100vh;
 }
 
+header .nav-sections h2 {
+  border-bottom: 2px solid var(--color-gray-2);
+}
+
 header .nav-sections h2,
 header .nav-sections h2 a:any-link {
   position: relative;
@@ -255,7 +259,6 @@ header .nav-sections h2 a:any-link {
   color: var(--color-gray-11);
   font-weight: 700;
   padding: 21px 0 18px;
-  border-bottom: 2px solid var(--color-gray-2);
   text-decoration: none;
 }
 


### PR DESCRIPTION
Removed double underlines on the mobile menu on the top level anchors

Test URLs:
- Before: https://main--bamboohr-website--hlxsites.hlx.page/marketplace/
- After: https://jgarrard-zz-978--bamboohr-website--hlxsites.hlx.page/marketplace/
