### PR TITLE
chore: re-add `header` rule to avoid CLS

### DIFF
--- a/blog/styles/styles.css
+++ b/blog/styles/styles.css
@@ -508,7 +508,7 @@ div.secondary-teal {
   --secondary-theme-shade15: var(--color-8-shade-15);
 }
 
-.header-wrapper {
+header, .header-wrapper {
   height: 70px;
 }
 


### PR DESCRIPTION
https://uncled-cls-fix--bamboohr-website--hlxsites.hlx.live/blog/the-era-fighting-the-ghost-of-employment-past

vs.

https://main--bamboohr-website--hlxsites.hlx.live/blog/the-era-fighting-the-ghost-of-employment-past

it seems like `CLS` regression has been introduced by https://github.com/hlxsites/bamboohr-website/commit/f6e9d3fee747fe3178b67e7d547536379a358c5f
i think i understand what's happening there, and my PR may impact some meganav sizing.
the `.*-wrapper` classes are only available once the block is loaded, which is why the CLS happens and it is probably also an indicator that those rules should be in the block css itself.

i think without trying to solve the problem of multiple headers, i think we can have the `header` sized to the current header and once we go live with mega nav just update the `header` to the new height... for meganav testing i think CLS is not super relevant...

<img width="689" alt="Screen Shot 2022-09-15 at 10 48 51 AM" src="https://user-images.githubusercontent.com/5289336/190461736-c8894cdb-acd6-4aab-9e2c-ee6d973c74ee.png">
<img width="688" alt="Screen Shot 2022-09-15 at 10 49 06 AM" src="https://user-images.githubusercontent.com/5289336/190461802-896500db-9b40-4706-80ab-98e1efb59177.png">
